### PR TITLE
fix priv cacerts path

### DIFF
--- a/config/compiletime.exs
+++ b/config/compiletime.exs
@@ -1,4 +1,6 @@
 import Config
 
 config :weather,
-  finch_config: [connect_options: [transport_opts: [cacertfile: "priv/cacerts.pem"]]]
+  finch_config: [
+    connect_options: [transport_opts: [cacertfile: "#{__DIR__}/../priv/cacerts.pem"]]
+  ]


### PR DESCRIPTION
Allows the escript to be run from a directory other than the root of the project.