### PR TITLE
add --every API switch

### DIFF
--- a/lib/weather/cli.ex
+++ b/lib/weather/cli.ex
@@ -8,16 +8,19 @@ defmodule Weather.CLI do
 
   @switches [
     help: :boolean,
+    every: :integer,
     latitude: :float,
     longitude: :float,
     api_key: :string,
     units: :string
   ]
 
-  @aliases [h: :help, t: :latitude, n: :longitude, a: :api_key, u: :units]
+  @aliases [h: :help, e: :every, t: :latitude, n: :longitude, a: :api_key, u: :units]
 
   @descriptions %{
     help: "Prints this help message",
+    every:
+      "Sets the hour interval at which data is reported for the 12-hour report. Defaults to 3.",
     latitude: "The latitude of the location for which to fetch weather data",
     longitude: "The longitude of the location for which to fetch weather data",
     api_key: "The OpenWeatherMap API key",

--- a/lib/weather/report/twelve_hour.ex
+++ b/lib/weather/report/twelve_hour.ex
@@ -1,10 +1,7 @@
 defmodule Weather.Report.TwelveHour do
   @moduledoc """
-  Generates a report for the next twelve hours, reporting every 3 hours (starting now).
+  Generates a report for the next twelve hours, reporting every N hours (starting now, N defaulting to 3).
   """
-
-  @every_n_hours 3
-  @num_datapoints 1 + div(12, @every_n_hours)
 
   @doc """
   Generate a twelve-hour report.
@@ -12,14 +9,14 @@ defmodule Weather.Report.TwelveHour do
   @spec generate({list(), map(), Weather.Opts.t()}) :: {list(), map(), Weather.Opts.t()}
   def generate({report, body, opts}) do
     report
-    |> add_twelve_hour_weather(body)
+    |> add_twelve_hour_weather(body, opts)
     |> then(&{&1, body, opts})
   end
 
-  defp add_twelve_hour_weather(report, body) do
+  defp add_twelve_hour_weather(report, body, opts) do
     {times, temps} =
       body
-      |> parse_data()
+      |> parse_data(opts)
       |> Enum.reduce({"", ""}, &add_to_time_and_temp_reports/2)
 
     [temps, times, "" | report]
@@ -37,10 +34,10 @@ defmodule Weather.Report.TwelveHour do
     }
   end
 
-  defp parse_data(body) do
+  defp parse_data(body, opts) do
     body["hourly"]
-    |> Enum.take_every(@every_n_hours)
-    |> Enum.take(@num_datapoints)
+    |> Enum.take_every(opts.every_n_hours)
+    |> Enum.take(1 + div(12, opts.every_n_hours))
     |> Enum.chunk_every(2, 1, [:empty])
     |> Enum.map(&parse_hourly(&1, body["timezone"]))
   end

--- a/test/weather_test.exs
+++ b/test/weather_test.exs
@@ -28,6 +28,18 @@ defmodule WeatherTest do
                Weather.get(context.opts)
     end
 
+    test "accepts an optional interval for the 12 hour report", context do
+      Req.Test.expect(Weather.API, fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "application/json")
+        |> Plug.Conn.send_resp(200, :json.encode(Clear.response()))
+      end)
+
+      assert {:ok,
+              " 76°  ⬆   77°  ⬇   76°  ⬇   74°  ⬇   71°  ⬇   68°  ⬇   64°  ⬇   62°  ⬇   61°  ⬇   60°  ⬇   59°  ⬇   58°  ⮕   58°    \n 3PM      4PM      5PM      6PM      7PM      8PM      9PM      10PM     11PM     12AM     1AM      2AM      3AM    \n\n77° | scattered clouds | 37% humidity"} =
+               Weather.get(%Weather.Opts{context.opts | every_n_hours: 1})
+    end
+
     test "displays alerts", context do
       stub(
         DateTime,


### PR DESCRIPTION
Allows passing in the hour interval for the 12 hour forecast (default is 3 hours). Value must be an integer between 1 and 12, inclusive.