### PR TITLE
add units validation

### DIFF
--- a/lib/weather/cli.ex
+++ b/lib/weather/cli.ex
@@ -27,7 +27,7 @@ defmodule Weather.CLI do
     longitude: "The longitude of the location for which to fetch weather data",
     api_key: "The OpenWeatherMap API key",
     units:
-      "The units in which to return the weather data. Options: 'metric' (celsius), 'imperial' (fahrenheit), 'standard' (kelvin)"
+      "The units in which to return the weather data. Options: 'metric' (celsius), 'celsius', 'imperial' (fahrenheit), 'fahrenheit', 'standard' (kelvin), 'kelvin'"
   }
 
   @doc """

--- a/lib/weather/opts.ex
+++ b/lib/weather/opts.ex
@@ -52,14 +52,15 @@ defmodule Weather.Opts do
          {:ok, latitude} <- latitude(parsed_args),
          {:ok, longitude} <- longitude(parsed_args),
          {:ok, every_n_hours} <- every_n_hours(parsed_args),
-         {:ok, colors} <- colors(parsed_args) do
+         {:ok, colors} <- colors(parsed_args),
+         {:ok, units} <- units(parsed_args) do
       %Weather.Opts{
         appid: api_key,
         colors: colors,
         every_n_hours: every_n_hours,
         latitude: latitude,
         longitude: longitude,
-        units: parsed_args[:units] || "imperial"
+        units: units
       }
     else
       {:error, reason} ->
@@ -83,6 +84,29 @@ defmodule Weather.Opts do
       colors when colors in [true, false] -> {:ok, colors}
       nil -> {:ok, true}
       colors -> {:error, "Invalid --colors. Expected a boolean. Received: #{inspect(colors)}"}
+    end
+  end
+
+  defp units(parsed_args) do
+    case parsed_args[:units] do
+      "celsius" ->
+        {:ok, "metric"}
+
+      "fahrenheit" ->
+        {:ok, "imperial"}
+
+      "kelvin" ->
+        {:ok, "standard"}
+
+      units when units in ["imperial", "metric", "standard"] ->
+        {:ok, units}
+
+      nil ->
+        {:ok, "imperial"}
+
+      units ->
+        {:error,
+         "Invalid --units. Expected 'imperial', 'fahrenheit', 'metric', 'celsius', 'standard', or 'kelvin'. Received: #{inspect(units)}"}
     end
   end
 


### PR DESCRIPTION
Only accept 'imperial', 'fahrenheit', 'metric', 'celsius', 'standard', and 'kelvin' as units. All other inputs are rejected.