### PR TITLE
adds --twelve CLI switch

### DIFF
--- a/lib/weather/cli.ex
+++ b/lib/weather/cli.ex
@@ -14,7 +14,8 @@ defmodule Weather.CLI do
     latitude: :float,
     longitude: :float,
     api_key: :string,
-    units: :string
+    units: :string,
+    twelve: :boolean
   ]
 
   @aliases [
@@ -25,7 +26,8 @@ defmodule Weather.CLI do
     t: :latitude,
     n: :longitude,
     a: :api_key,
-    u: :units
+    u: :units,
+    w: :twelve
   ]
 
   @descriptions %{
@@ -38,6 +40,8 @@ defmodule Weather.CLI do
     latitude: "The latitude of the location for which to fetch weather data",
     longitude: "The longitude of the location for which to fetch weather data",
     api_key: "The OpenWeatherMap API key",
+    twelve:
+      "Enables 12-hour time format for the hourly report. Defaults to true. When false, 24-hour time format is used",
     units:
       "The units in which to return the weather data. Options: 'metric' (celsius), 'celsius', 'imperial' (fahrenheit), 'fahrenheit', 'standard' (kelvin), 'kelvin'"
   }

--- a/lib/weather/opts.ex
+++ b/lib/weather/opts.ex
@@ -19,6 +19,9 @@ defmodule Weather.Opts do
 
     * `:longitude` - a float representing the longitude of your location.
 
+    * `:twelve` - a boolean representing whether to use 12-hour time format for
+      the hourly report. Defaults to true. When false, 24-hour time format is used.
+
     * `:units` - a string representing the units of measurement. Default is
       "imperial" (Fahrenheit). Other options are "metric" (Celsius) and
       "standard" (Kelvin).
@@ -31,6 +34,7 @@ defmodule Weather.Opts do
           hours: integer(),
           latitude: float(),
           longitude: float(),
+          twelve: boolean(),
           units: String.t()
         }
 
@@ -41,10 +45,11 @@ defmodule Weather.Opts do
           hours: integer(),
           latitude: float(),
           longitude: float(),
+          twelve: boolean(),
           units: String.t()
         ]
 
-  @keys [:latitude, :longitude, :appid, :colors, :every_n_hours, :hours, :units]
+  @keys [:latitude, :longitude, :appid, :colors, :every_n_hours, :hours, :twelve, :units]
   @enforce_keys @keys
   defstruct @keys
 
@@ -59,6 +64,7 @@ defmodule Weather.Opts do
          {:ok, hours} <- hours(parsed_args),
          {:ok, every_n_hours} <- every_n_hours(hours, parsed_args),
          {:ok, colors} <- colors(parsed_args),
+         {:ok, twelve} <- twelve(parsed_args),
          {:ok, units} <- units(parsed_args) do
       %Weather.Opts{
         appid: api_key,
@@ -67,6 +73,7 @@ defmodule Weather.Opts do
         hours: hours,
         latitude: latitude,
         longitude: longitude,
+        twelve: twelve,
         units: units
       }
     else
@@ -88,9 +95,17 @@ defmodule Weather.Opts do
 
   defp colors(parsed_args) do
     case parsed_args[:colors] do
-      colors when colors in [true, false] -> {:ok, colors}
+      colors when is_boolean(colors) -> {:ok, colors}
       nil -> {:ok, true}
       colors -> {:error, "Invalid --colors. Expected a boolean. Received: #{inspect(colors)}"}
+    end
+  end
+
+  defp twelve(parsed_args) do
+    case parsed_args[:twelve] do
+      twelve when is_boolean(twelve) -> {:ok, twelve}
+      nil -> {:ok, true}
+      twelve -> {:error, "Invalid --twelve. Expected a boolean. Received: #{inspect(twelve)}"}
     end
   end
 

--- a/lib/weather/report/hourly.ex
+++ b/lib/weather/report/hourly.ex
@@ -45,12 +45,12 @@ defmodule Weather.Report.Hourly do
     |> Enum.take_every(opts.every_n_hours)
     |> Enum.take(1 + div(opts.hours, opts.every_n_hours))
     |> Enum.chunk_every(2, 1, [:empty])
-    |> Enum.map(&parse_hourly(&1, body["timezone"]))
+    |> Enum.map(&parse_hourly(&1, body["timezone"], opts))
   end
 
-  defp parse_hourly([current_data, next_data], timezone) do
+  defp parse_hourly([current_data, next_data], timezone, opts) do
     %{
-      time: time(current_data, timezone),
+      time: time(current_data, timezone, opts),
       temp: temp(current_data),
       arrow: arrow(current_data, next_data)
     }
@@ -78,10 +78,12 @@ defmodule Weather.Report.Hourly do
     end
   end
 
-  defp time(data, timezone) do
+  defp time(data, timezone, opts) do
+    format = if opts.twelve, do: "%-I%p", else: "%0H"
+
     data
     |> datetime(timezone)
-    |> Calendar.strftime("%-I%p")
+    |> Calendar.strftime(format)
   end
 
   defp datetime(data, timezone) do

--- a/test/weather_test.exs
+++ b/test/weather_test.exs
@@ -34,7 +34,7 @@ defmodule WeatherTest do
                Weather.get(context.opts)
     end
 
-    test "accepts an optional interval for the hourly report", context do
+    test "accepts an optional length for the hourly report", context do
       Req.Test.expect(Weather.API, fn conn ->
         conn
         |> Plug.Conn.put_resp_header("content-type", "application/json")
@@ -45,6 +45,30 @@ defmodule WeatherTest do
                :ok,
                " 76°  ⬇   74°  ⬇   64°  ⬇   60°  ⬇   58°  ⮕   58°  ⬆   67°  ⬆   69°  ⬇   65°    \n 3PM      6PM      9PM      12AM     3AM      6AM      9AM      12PM     3PM    \n\n77° | scattered clouds | 37% humidity"
              } = Weather.get(%Weather.Opts{context.opts | hours: 24})
+    end
+
+    test "accepts an optional interval for the hourly report", context do
+      Req.Test.expect(Weather.API, fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "application/json")
+        |> Plug.Conn.send_resp(200, :json.encode(Clear.response()))
+      end)
+
+      assert {:ok,
+              " 76°  ⬇   64°  ⬇   58°    \n 3PM      9PM      3AM    \n\n77° | scattered clouds | 37% humidity"} =
+               Weather.get(%Weather.Opts{context.opts | every_n_hours: 6})
+    end
+
+    test "supports 24-hour format", context do
+      Req.Test.expect(Weather.API, fn conn ->
+        conn
+        |> Plug.Conn.put_resp_header("content-type", "application/json")
+        |> Plug.Conn.send_resp(200, :json.encode(Clear.response()))
+      end)
+
+      assert {:ok,
+              " 76°  ⬇   74°  ⬇   64°  ⬇   60°  ⬇   58°    \n 15       18       21       00       03     \n\n77° | scattered clouds | 37% humidity"} =
+               Weather.get(%Weather.Opts{context.opts | twelve: false})
     end
 
     test "displays alerts", context do


### PR DESCRIPTION
Allows the user to specify whether they want the time in 12-hour or 24-hour format. The default is 12-hour format.