### PR TITLE
move finch config to mix.exs

### DIFF
--- a/config/compiletime.exs
+++ b/config/compiletime.exs
@@ -1,8 +1,3 @@
 import Config
 
-config :weather,
-  finch_config: [
-    connect_options: [transport_opts: [cacertfile: "#{__DIR__}/../priv/cacerts.pem"]]
-  ]
-
 config :elixir, :time_zone_database, Tz.TimeZoneDatabase

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,11 @@ defmodule Weather.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:logger],
+      env: [
+        # https://github.com/wojtekmach/req/issues/299
+        finch_config: [connect_options: [transport_opts: [cacertfile: "#{__DIR__}/priv/cacerts.pem"]]]
+      ]
     ]
   end
 


### PR DESCRIPTION
Moves the finch config from config/compiletime.exs to mix.exs. This ensures the configuration is available when this library is used as a dependency (in which case the config is ignored).