### PR TITLE
add --test switch

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -176,7 +176,7 @@
           {Credo.Check.Readability.Specs, []},
           {Credo.Check.Readability.StrictModuleLayout, []},
           {Credo.Check.Readability.WithCustomTaggedTuple, []},
-          {Credo.Check.Refactor.ABCSize, [max_size: 50]},
+          {Credo.Check.Refactor.ABCSize, [max_size: 100]},
           {Credo.Check.Refactor.AppendSingleItem, []},
           {Credo.Check.Refactor.DoubleBooleanNegation, []},
           {Credo.Check.Refactor.FilterReject, []},

--- a/lib/weather/api.ex
+++ b/lib/weather/api.ex
@@ -3,13 +3,16 @@ defmodule Weather.API do
   Fetches weather data from the OpenWeatherMap API.
   """
 
+  alias Weather.Fixtures.TestResponse.Clear
+  alias Weather.Fixtures.TestResponse.Storm
+
   @url "https://api.openweathermap.org/data/3.0/onecall"
 
   @doc """
   Fetches weather data from the OpenWeatherMap API.
   """
   @spec fetch_weather(Weather.Opts.t()) :: {:ok, Req.Response.t()} | {:error, Exception.t()}
-  def fetch_weather(%Weather.Opts{} = opts) do
+  def fetch_weather(%Weather.Opts{test: nil} = opts) do
     :weather
     |> Application.get_env(:finch_config)
     |> Req.default_options()
@@ -18,6 +21,11 @@ defmodule Weather.API do
     |> req_opts()
     |> Req.request()
   end
+
+  def fetch_weather(%Weather.Opts{test: test}), do: {:ok, Req.Response.new(status: 200, body: fake_body(test))}
+
+  defp fake_body("clear"), do: Clear.response()
+  defp fake_body("storm"), do: Storm.response()
 
   defp req_opts(opts) do
     Keyword.merge(

--- a/lib/weather/cli.ex
+++ b/lib/weather/cli.ex
@@ -15,6 +15,7 @@ defmodule Weather.CLI do
     longitude: :float,
     api_key: :string,
     units: :string,
+    test: :string,
     twelve: :boolean
   ]
 
@@ -27,6 +28,7 @@ defmodule Weather.CLI do
     n: :longitude,
     a: :api_key,
     u: :units,
+    s: :test,
     w: :twelve
   ]
 
@@ -40,10 +42,11 @@ defmodule Weather.CLI do
     latitude: "The latitude of the location for which to fetch weather data",
     longitude: "The longitude of the location for which to fetch weather data",
     api_key: "The OpenWeatherMap API key",
+    test: "Fake weather data for testing purposes. Options: \"clear\", \"storm\"",
     twelve:
       "Enables 12-hour time format for the hourly report. Defaults to true. When false, 24-hour time format is used",
     units:
-      "The units in which to return the weather data. Options: 'metric' (celsius), 'celsius', 'imperial' (fahrenheit), 'fahrenheit', 'standard' (kelvin), 'kelvin'"
+      "The units in which to return the weather data. Options: \"metric\" (celsius), \"celsius\", \"imperial\" (fahrenheit), \"fahrenheit\", \"standard\" (kelvin), \"kelvin\""
   }
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -92,5 +92,5 @@ defmodule Weather.MixProject do
   end
 
   defp elixirc_paths(:test), do: ["lib", "test/fixtures", "test/mocks"]
-  defp elixirc_paths(_), do: ["lib"]
+  defp elixirc_paths(_), do: ["lib", "test/fixtures"]
 end

--- a/test/fixtures/test_response/storm.ex
+++ b/test/fixtures/test_response/storm.ex
@@ -1521,8 +1521,8 @@ defmodule Weather.Fixtures.TestResponse.Storm do
           "wind_speed" => 5.21
         }
       ],
-      "lat" => 40.0978,
-      "lon" => -92.4169,
+      "lat" => 42.3871,
+      "lon" => -87.9562,
       "minutely" => [
         %{"dt" => 1_719_970_080, "precipitation" => 34.5082},
         %{"dt" => 1_719_970_140, "precipitation" => 35.4856},

--- a/test/weather_test.exs
+++ b/test/weather_test.exs
@@ -199,5 +199,10 @@ defmodule WeatherTest do
              } =
                Weather.get(%Weather.Opts{context.opts | units: "standard", colors: true})
     end
+
+    test "supports returning test data, which doesn't require an API key, latitude, or longitude to be present" do
+      opts = Weather.Opts.new(test: "clear", colors: false)
+      assert {:ok, "\n76°  ⬇   74°  ⬇   64°  ⬇   60°  ⬇   58°     \n3PM      6PM      9PM      12AM     3AM     \n\n77° | scattered clouds | 37% humidity\n"} = Weather.get(opts)
+    end
   end
 end


### PR DESCRIPTION
Allows the user to:
1. Test output for different weather types (clear, storm)
2. Test the application without having an API key set up