### PR TITLE
move test responses test/ -> lib/

### DIFF
--- a/lib/weather/api.ex
+++ b/lib/weather/api.ex
@@ -3,9 +3,9 @@ defmodule Weather.API do
   Fetches weather data from the OpenWeatherMap API.
   """
 
-  alias Weather.Fixtures.TestResponse.Clear
-  alias Weather.Fixtures.TestResponse.Rain
-  alias Weather.Fixtures.TestResponse.Storm
+  alias Weather.TestResponse.Clear
+  alias Weather.TestResponse.Rain
+  alias Weather.TestResponse.Storm
 
   @url "https://api.openweathermap.org/data/3.0/onecall"
 

--- a/lib/weather/test_response/bad_request.ex
+++ b/lib/weather/test_response/bad_request.ex
@@ -1,4 +1,4 @@
-defmodule Weather.Fixtures.TestResponse.BadRequest do
+defmodule Weather.TestResponse.BadRequest do
   @moduledoc false
 
   @spec response() :: map()

--- a/lib/weather/test_response/clear.ex
+++ b/lib/weather/test_response/clear.ex
@@ -1,4 +1,4 @@
-defmodule Weather.Fixtures.TestResponse.Clear do
+defmodule Weather.TestResponse.Clear do
   @moduledoc false
 
   @spec response() :: map()

--- a/lib/weather/test_response/rain.ex
+++ b/lib/weather/test_response/rain.ex
@@ -1,4 +1,4 @@
-defmodule Weather.Fixtures.TestResponse.Rain do
+defmodule Weather.TestResponse.Rain do
   @moduledoc false
 
   @spec response() :: map()

--- a/lib/weather/test_response/storm.ex
+++ b/lib/weather/test_response/storm.ex
@@ -1,4 +1,4 @@
-defmodule Weather.Fixtures.TestResponse.Storm do
+defmodule Weather.TestResponse.Storm do
   @moduledoc false
 
   @spec response() :: map()

--- a/lib/weather/test_response/unauthorized.ex
+++ b/lib/weather/test_response/unauthorized.ex
@@ -1,4 +1,4 @@
-defmodule Weather.Fixtures.TestResponse.Unauthorized do
+defmodule Weather.TestResponse.Unauthorized do
   @moduledoc false
 
   @spec response() :: map()

--- a/mix.exs
+++ b/mix.exs
@@ -94,6 +94,5 @@ defmodule Weather.MixProject do
     [main_module: Weather.CLI, name: :weather, strip_beams: true, embed_elixir: true]
   end
 
-  defp elixirc_paths(:test), do: ["lib", "test/fixtures", "test/mocks"]
-  defp elixirc_paths(_), do: ["lib", "test/fixtures"]
+  defp elixirc_paths(_), do: ["lib"]
 end

--- a/test/weather_test.exs
+++ b/test/weather_test.exs
@@ -2,11 +2,11 @@ defmodule WeatherTest do
   @moduledoc nodoc: true
   use ExUnit.Case, async: true
 
-  alias Weather.Fixtures.TestResponse.BadRequest
-  alias Weather.Fixtures.TestResponse.Clear
-  alias Weather.Fixtures.TestResponse.Rain
-  alias Weather.Fixtures.TestResponse.Storm
-  alias Weather.Fixtures.TestResponse.Unauthorized
+  alias Weather.TestResponse.BadRequest
+  alias Weather.TestResponse.Clear
+  alias Weather.TestResponse.Rain
+  alias Weather.TestResponse.Storm
+  alias Weather.TestResponse.Unauthorized
 
   doctest Weather
 


### PR DESCRIPTION
tests are not included when this library is included in another project as a dependency, and so the test responses were not available. By moving them to lib/, they will always be available.