### PR TITLE
add hourly rain report

### DIFF
--- a/lib/weather/report.ex
+++ b/lib/weather/report.ex
@@ -6,7 +6,8 @@ defmodule Weather.Report do
   alias Weather.Report.Alerts
   alias Weather.Report.Current
   alias Weather.Report.Hourly
-  alias Weather.Report.Rain
+  alias Weather.Report.RainHourly
+  alias Weather.Report.RainMinutely
   alias Weather.Report.SunriseSunset
 
   @padding "\n"
@@ -20,9 +21,10 @@ defmodule Weather.Report do
     {[], resp.body, opts}
     |> Alerts.generate()
     |> Current.generate()
-    |> SunriseSunset.generate()
     |> Hourly.generate()
-    |> Rain.generate()
+    |> SunriseSunset.generate()
+    |> RainHourly.generate()
+    |> RainMinutely.generate()
     |> aggregate_report()
     |> add_padding()
   end

--- a/lib/weather/report/rain_hourly.ex
+++ b/lib/weather/report/rain_hourly.ex
@@ -1,0 +1,58 @@
+defmodule Weather.Report.RainHourly do
+  @moduledoc """
+  Generates a chart showing rain intensity each minute for the next hour.
+  """
+
+  alias Weather.DateUtils
+
+  @max_hours 24
+
+  @doc """
+  Generates a rain report.
+  """
+  @spec generate({list(), map(), Weather.Opts.t()}) :: {list(), map(), Weather.Opts.t()}
+  def generate({report, body, %Weather.Opts{} = opts}) do
+    body
+    |> raining_streaks(opts)
+    |> Enum.map(fn streak ->
+      starting = DateUtils.time_by_hour(streak[:start], body["timezone"], opts)
+      ending = DateUtils.time_by_hour(streak[:end], body["timezone"], opts)
+      "#{starting} - #{ending}"
+    end)
+    |> add_to_report(report, body, opts)
+  end
+
+  defp add_to_report([], report, body, opts), do: {report, body, opts}
+
+  defp add_to_report(rain_streaks, report, body, opts) do
+    rain_report = "☔ " <> Enum.join(rain_streaks, ", ")
+    {[rain_report | report], body, opts}
+  end
+
+  defp raining_streaks(body, opts) do
+    body["hourly"]
+    |> Enum.take(1 + min(opts.hours, @max_hours))
+    |> Enum.reduce([], &process_hourly/2)
+    |> Enum.reverse()
+    |> Enum.filter(fn streak -> streak.raining and Map.has_key?(streak, :end) end)
+  end
+
+  defp process_hourly(data, []), do: [%{start: data["dt"], raining: Map.has_key?(data, "rain")}]
+
+  defp process_hourly(data, acc) do
+    data
+    |> Map.has_key?("rain")
+    |> process_streaks(data, acc)
+  end
+
+  defp process_streaks(raining, _, [%{raining: raining} | _] = acc), do: acc
+
+  defp process_streaks(raining, data, acc) do
+    [streak | rest] = acc
+    %{"dt" => dt} = data
+    completed_streak = Map.put(streak, :end, dt)
+    new_streak = %{start: dt, raining: raining}
+
+    [new_streak, completed_streak | rest]
+  end
+end

--- a/lib/weather/report/rain_minutely.ex
+++ b/lib/weather/report/rain_minutely.ex
@@ -1,4 +1,4 @@
-defmodule Weather.Report.Rain do
+defmodule Weather.Report.RainMinutely do
   @moduledoc """
   Generates a chart showing rain intensity each minute for the next hour.
   """

--- a/test/weather_test.exs
+++ b/test/weather_test.exs
@@ -34,10 +34,10 @@ defmodule WeatherTest do
                :ok,
                """
 
+               🌞 5:17AM | 🌚 8:25PM
+
                76°  ⬇   74°  ⬇   64°  ⬇   60°  ⬇   58°
                3PM      6PM      9PM      12AM     3AM
-
-               🌞 5:17AM | 🌚 8:25PM
 
                77° | scattered clouds | 37% humidity
                """
@@ -55,10 +55,10 @@ defmodule WeatherTest do
                :ok,
                """
 
+               🌞 5:17AM | 🌚 8:25PM
+
                76°  ⬇   74°  ⬇   64°  ⬇   60°  ⬇   58°  ⮕   58°  ⬆   67°  ⬆   69°  ⬇   65°
                3PM      6PM      9PM      12AM     3AM      6AM      9AM      12PM     3PM
-
-               🌞 5:17AM | 🌚 8:25PM
 
                77° | scattered clouds | 37% humidity
                """
@@ -76,10 +76,10 @@ defmodule WeatherTest do
                :ok,
                """
 
+               🌞 5:17AM | 🌚 8:25PM
+
                76°  ⬇   64°  ⬇   58°
                3PM      9PM      3AM
-
-               🌞 5:17AM | 🌚 8:25PM
 
                77° | scattered clouds | 37% humidity
                """
@@ -97,10 +97,10 @@ defmodule WeatherTest do
                :ok,
                """
 
+               🌞 05:17 | 🌚 20:25
+
                76°  ⬇   74°  ⬇   64°  ⬇   60°  ⬇   58°
                15       18       21       00       03\s
-
-               🌞 05:17 | 🌚 20:25
 
                77° | scattered clouds | 37% humidity
                """
@@ -128,10 +128,12 @@ defmodule WeatherTest do
                [............................................................]
                                +              +              +\s\s\s\s\s\s\s\s\s\s\s\s\s\s\s
 
-               77°  ⬇   73°  ⬇   70°  ⬇   68°  ⬆   72°
-               8PM      11PM     2AM      5AM      8AM
+               ☔ 9PM - 2AM
 
                🌞 5:44AM | 🌚 8:42PM
+
+               77°  ⬇   73°  ⬇   70°  ⬇   68°  ⬆   72°
+               8PM      11PM     2AM      5AM      8AM
 
                77° | very heavy rain | 76% humidity
 
@@ -280,10 +282,12 @@ defmodule WeatherTest do
                [............................................................]
                                +              +              +\s\s\s\s\s\s\s\s\s\s\s\s\s\s\s
 
-               77°  ⬇   73°  ⬇   70°  ⬇   68°  ⬆   72°
-               8PM      11PM     2AM      5AM      8AM
+               ☔ 9PM - 2AM
 
                🌞 5:44AM | 🌚 8:42PM
+
+               77°  ⬇   73°  ⬇   70°  ⬇   68°  ⬆   72°
+               8PM      11PM     2AM      5AM      8AM
 
                77° | very heavy rain | 76% humidity
 
@@ -321,10 +325,12 @@ defmodule WeatherTest do
                [............................................................]
                                +              +              +\s\s\s\s\s\s\s\s\s\s\s\s\s\s\s
 
-               66°  ⬇   65°  ⬆   67°  ⬆   73°  ⬇   71°
-               7AM      10AM     1PM      4PM      7PM
+               ☔ 7AM - 9AM, 10AM - 12PM
 
                🌞 6:01AM | 🌚 7:52PM
+
+               66°  ⬇   65°  ⬆   67°  ⬆   73°  ⬇   71°
+               7AM      10AM     1PM      4PM      7PM
 
                66° | moderate rain | 92% humidity
                """
@@ -352,10 +358,12 @@ defmodule WeatherTest do
                [............................................................]
                                +              +              +\s\s\s\s\s\s\s\s\s\s\s\s\s\s\s
 
-               77°  ⬇   73°  ⬇   70°  ⬇   68°  ⬆   72°
-               8PM      11PM     2AM      5AM      8AM
+               ☔ 9PM - 2AM
 
                🌞 5:44AM | 🌚 8:42PM
+
+               77°  ⬇   73°  ⬇   70°  ⬇   68°  ⬆   72°
+               8PM      11PM     2AM      5AM      8AM
 
                77° | very heavy rain | 76% humidity
                """
@@ -383,10 +391,12 @@ defmodule WeatherTest do
                [............................................................]
                                +              +              +\s\s\s\s\s\s\s\s\s\s\s\s\s\s\s
 
-               \e[38;5;214m77°\e[0m  ⬇   \e[38;5;214m73°\e[0m  ⬇   \e[38;5;214m70°\e[0m  ⬇   \e[38;5;226m68°\e[0m  ⬆   \e[38;5;214m72°\e[0m
-               8PM      11PM     2AM      5AM      8AM
+               ☔ 9PM - 2AM
 
                🌞 5:44AM | 🌚 8:42PM
+
+               \e[38;5;214m77°\e[0m  ⬇   \e[38;5;214m73°\e[0m  ⬇   \e[38;5;214m70°\e[0m  ⬇   \e[38;5;226m68°\e[0m  ⬆   \e[38;5;214m72°\e[0m
+               8PM      11PM     2AM      5AM      8AM
 
                77° | very heavy rain | 76% humidity
 
@@ -536,10 +546,12 @@ defmodule WeatherTest do
                [............................................................]
                                +              +              +\s\s\s\s\s\s\s\s\s\s\s\s\s\s\s
 
-               66°  ⬇   65°  ⬆   67°  ⬆   73°  ⬇   71°
-               07       10       13       16       19\s
+               ☔ 07 - 09, 10 - 12
 
                🌞 06:01 | 🌚 19:52
+
+               66°  ⬇   65°  ⬆   67°  ⬆   73°  ⬇   71°
+               07       10       13       16       19\s
 
                66° | moderate rain | 92% humidity
                """
@@ -610,10 +622,10 @@ defmodule WeatherTest do
                :ok,
                """
 
+               🌞 5:17AM | 🌚 8:25PM
+
                76°  ⬇   74°  ⬇   64°  ⬇   60°  ⬇   58°
                3PM      6PM      9PM      12AM     3AM
-
-               🌞 5:17AM | 🌚 8:25PM
 
                77° | scattered clouds | 37% humidity
                """
@@ -631,10 +643,10 @@ defmodule WeatherTest do
                :ok,
                """
 
+               🌞 5:17AM | 🌚 8:25PM
+
                \e[38;5;214m76°\e[0m  ⬇   \e[38;5;214m74°\e[0m  ⬇   \e[38;5;226m64°\e[0m  ⬇   \e[38;5;226m60°\e[0m  ⬇   \e[38;5;148m58°\e[0m
                3PM      6PM      9PM      12AM     3AM
-
-               🌞 5:17AM | 🌚 8:25PM
 
                77° | scattered clouds | 37% humidity
                """
@@ -652,10 +664,10 @@ defmodule WeatherTest do
                :ok,
                """
 
+               🌞 5:17AM | 🌚 8:25PM
+
                \e[38;5;88m76°\e[0m  ⬇   \e[38;5;88m74°\e[0m  ⬇   \e[38;5;88m64°\e[0m  ⬇   \e[38;5;88m60°\e[0m  ⬇   \e[38;5;88m58°\e[0m
                3PM      6PM      9PM      12AM     3AM
-
-               🌞 5:17AM | 🌚 8:25PM
 
                77° | scattered clouds | 37% humidity
                """
@@ -673,10 +685,10 @@ defmodule WeatherTest do
                :ok,
                """
 
+               🌞 5:17AM | 🌚 8:25PM
+
                \e[38;5;245m76°\e[0m  ⬇   \e[38;5;245m74°\e[0m  ⬇   \e[38;5;245m64°\e[0m  ⬇   \e[38;5;245m60°\e[0m  ⬇   \e[38;5;245m58°\e[0m
                3PM      6PM      9PM      12AM     3AM
-
-               🌞 5:17AM | 🌚 8:25PM
 
                77° | scattered clouds | 37% humidity
                """
@@ -690,10 +702,10 @@ defmodule WeatherTest do
                :ok,
                """
 
+               🌞 5:17AM | 🌚 8:25PM
+
                76°  ⬇   74°  ⬇   64°  ⬇   60°  ⬇   58°
                3PM      6PM      9PM      12AM     3AM
-
-               🌞 5:17AM | 🌚 8:25PM
 
                77° | scattered clouds | 37% humidity
                """


### PR DESCRIPTION
Reports on rain "streaks" (e.g. 1PM - 2PM) where
there is rain forecasted within the duration, up
to 24 hours (less if hourly report is reporting on < 24 hours).

Also moves the sunset/sunrise report up above the
hourly temps.

Also renames `Weather.Report.Rain` -> `Weather.Report.RainMinutely`.