### PR TITLE
fix hourly rain bug for current hour

### DIFF
--- a/lib/weather/report/rain_hourly.ex
+++ b/lib/weather/report/rain_hourly.ex
@@ -34,18 +34,39 @@ defmodule Weather.Report.RainHourly do
   defp raining_streaks(body, opts) do
     body["hourly"]
     |> Enum.take(1 + min(opts.hours, @max_hours))
-    |> Enum.reduce([], &process_hourly/2)
+    |> Enum.with_index()
+    |> Enum.reduce([], fn hourly, acc -> process_hourly(hourly, body, acc) end)
     |> Enum.reverse()
     |> Enum.filter(fn streak -> streak.raining and Map.has_key?(streak, :end) end)
   end
 
-  defp process_hourly(data, []), do: [%{start: data["dt"], raining: Map.has_key?(data, "rain")}]
+  defp process_hourly({data, idx}, body, []),
+    do: [%{start: data["dt"], raining: raining?(data, body, idx)}]
 
-  defp process_hourly(data, acc) do
+  defp process_hourly({data, idx}, body, acc) do
     data
-    |> Map.has_key?("rain")
+    |> raining?(body, idx)
     |> process_streaks(data, acc)
   end
+
+  defp raining?(data, body, 0), do: raining?(data, body, 1) and rain_before_next_hour?(body)
+
+  defp raining?(data, _, _), do: Map.has_key?(data, "rain")
+
+  defp rain_before_next_hour?(%{"current" => current, "minutely" => minutely}) do
+    current_dt = current["dt"]
+    current_hour = DateTime.from_unix!(current_dt).hour
+
+    Enum.any?(minutely, fn data ->
+      data["precipitation"] > 0 and
+        data["dt"] >= current_dt and
+        DateTime.from_unix!(data["dt"]).hour == current_hour
+    end)
+  end
+
+  # minutely data isn't available. let's just assume it's raining since hourly weather
+  # indicates it's going to be raining during this hour.
+  defp rain_before_next_hour?(_), do: true
 
   defp process_streaks(raining, _, [%{raining: raining} | _] = acc), do: acc
 


### PR DESCRIPTION
Fixes a bug where the hourly rain report would report rain for the current hour, when no more rain was expected between <now> and the end of the hour.