### PR TITLE
inspect: only redact appid when not nil

### DIFF
--- a/lib/weather/opts.ex
+++ b/lib/weather/opts.ex
@@ -334,7 +334,10 @@ defimpl Inspect, for: Weather.Opts do
   @spec inspect(Weather.Opts.t(), Inspect.Opts.t()) :: binary()
   def inspect(weather_opts, opts) do
     weather_opts
-    |> Map.put(:appid, "<<REDACTED>>")
+    |> redact_appid()
     |> Inspect.Any.inspect(opts)
   end
+
+  defp redact_appid(%Weather.Opts{appid: nil} = weather_opts), do: weather_opts
+  defp redact_appid(weather_opts), do: Map.put(weather_opts, :appid, "<<REDACTED>>")
 end


### PR DESCRIPTION
If appid is set to nil on Weather.Opts, we no longer show "<<REDACTED>>" when inspecting, and instead show that it's nil.