### PR TITLE
better error message for bad api key w/ zip

### DIFF
--- a/lib/weather/opts.ex
+++ b/lib/weather/opts.ex
@@ -332,9 +332,17 @@ defmodule Weather.Opts do
           %__MODULE__{opts | latitude: latitude, longitude: longitude, label: label_from_zip}
         }
 
-      {:ok, _} ->
-        {:error,
-         "Invalid --zip. Value provided must be a valid zip code. Received: #{inspect(zip)}"}
+      {:ok, resp} ->
+        {
+          :error,
+          """
+          Unable to fetch location data for zip '#{zip}' (status: #{resp.status})
+
+          Response from OpenWeatherMap:
+
+          #{resp.body["message"]}
+          """
+        }
 
       {:error, exception} ->
         {:error,


### PR DESCRIPTION
When a bad api key is provided and a zip code is passed to Weather.Opts.new/1, the error message is now more informative and points to an invalid API key. Previously, the error message stated the zip code was bad.